### PR TITLE
Fix: Prevent double-saving of blog posts in Saved Blogs

### DIFF
--- a/BlogiFy/blog.js
+++ b/BlogiFy/blog.js
@@ -1,24 +1,3 @@
-document.getElementById("save-btn").addEventListener("click", function () {
-    const title = document.getElementById("title").value;
-    const content = document.getElementById("content").value;
-    const image = document.getElementById("image").files[0];
-  
-    const blogPost = {
-      title: title,
-      content: content,
-      date: new Date().toLocaleString(),
-      image: image ? URL.createObjectURL(image) : null,
-      category: document.getElementById("category").value, 
-    };
-  
-    let posts = JSON.parse(localStorage.getItem("blogPosts")) || [];
-    posts.push(blogPost);
-    localStorage.setItem("blogPosts", JSON.stringify(posts));
-  
-    alert("Blog saved to local storage!");
-    window.location.href = "savedBlogs.html"; 
-  });
-  
   document.getElementById("blog-form").addEventListener("submit", function (e) {
     e.preventDefault(); 
   


### PR DESCRIPTION
- Resolved an issue where the blog is getting saved twice when clicked on save button.
- handles it by removing the event listener for the "submit" action in blog.js.
- verified it and it is working fine now.