### PR TITLE
Added light/dark mode toggle (fix #30)

### DIFF
--- a/OpenFlash/css/style.css
+++ b/OpenFlash/css/style.css
@@ -162,3 +162,31 @@ textarea:focus {
 .fade-in {
     animation: fadeIn 0.3s ease-out forwards;
 }
+
+.view-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-right: 1rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+
+body.dark-mode {
+  background-color: #121212;
+  color: #ffffff;
+      --text-1: #e0e0e0; 
+}
+
+body.dark-mode a {
+  color: #90caf9;
+}
+

--- a/OpenFlash/js/views/home.js
+++ b/OpenFlash/js/views/home.js
@@ -6,14 +6,47 @@ export function render() {
     const container = createElement('div', 'home-view fade-in');
     
     // Header
-    const header = createElement('header', 'view-header');
-    header.innerHTML = `
-        <h1>My Decks</h1>
-        <a href="#/create" class="btn btn-primary">
-            + Create New Deck
-        </a>
-    `;
+const header = createElement('header', 'view-header');
+
+header.innerHTML = `
+  <div class="header-left">
+    <h1>My Decks</h1>
+  </div>
+
+  <div class="header-right">
+    <label class="theme-toggle">
+      <input type="checkbox" id="theme-toggle" />
+      <span>Dark Mode</span>
+    </label>
+
+    <a href="#/create" class="btn btn-primary">
+      + Create New Deck
+    </a>
+  </div>
+`;
+
     container.appendChild(header);
+    
+const toggle = header.querySelector('#theme-toggle');
+
+
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+  document.body.classList.add('dark-mode');
+  toggle.checked = true;
+}
+
+// Toggle theme on change
+toggle.addEventListener('change', () => {
+  if (toggle.checked) {
+    document.body.classList.add('dark-mode');
+    localStorage.setItem('theme', 'dark');
+  } else {
+    document.body.classList.remove('dark-mode');
+    localStorage.setItem('theme', 'light');
+  }
+});
+
 
     // Deck List
     const decks = StorageManager.getDecks();


### PR DESCRIPTION
- Added a light/dark mode toggle to the main header on the Home view
- Implemented theme persistence using localStorage
- Updated Home view header to include theme toggle
- Added dark mode styles scoped to body.dark-mode

Fixes #30


![Screenshot 2026-01-21 131244](https://github.com/user-attachments/assets/c20bb957-13a5-481f-8425-47fef269b45c)
