### PR TITLE
OpenFlash: Randomize card order (Add shuffle mode for study sessions)

### DIFF
--- a/OpenFlash/css/components.css
+++ b/OpenFlash/css/components.css
@@ -30,6 +30,7 @@
     display: flex;
     gap: var(--space-sm);
     margin-top: auto;
+    flex-wrap: wrap;
 }
 
 .btn-outline {
@@ -192,4 +193,44 @@
 .stats-box {
     margin: var(--space-md) 0;
     font-size: 1.2rem;
+}
+.shuffle-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.shuffle-checkbox {
+    display: none;
+}
+
+.slider {
+    width: 34px;
+    height: 18px;
+    background: #ccc;
+    border-radius: 999px;
+    position: relative;
+    transition: background 0.2s;
+}
+
+.slider::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    background: white;
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.2s;
+}
+
+.shuffle-checkbox:checked + .slider {
+    background: var(--primary);
+}
+
+.shuffle-checkbox:checked + .slider::after {
+    transform: translateX(16px);
 }

--- a/OpenFlash/js/views/home.js
+++ b/OpenFlash/js/views/home.js
@@ -4,7 +4,7 @@ import { Toast } from '../toast.js';
 
 export function render() {
     const container = createElement('div', 'home-view fade-in');
-    
+
     // Header
     const header = createElement('header', 'view-header');
     header.innerHTML = `
@@ -42,42 +42,66 @@ export function render() {
                 </div>
                 </div>
                 <div class="deck-actions">
-                    <a href="#/study/${deck.id}" class="btn btn-primary">Study</a>
+                
+<label class="shuffle-switch">
+  <input
+    type="checkbox"
+    class="shuffle-checkbox"
+    data-id="${deck.id}"
+  />
+  <span class="slider"></span>
+  <span class="label-text">Shuffle</span>
+</label>
+
+
+<button class="btn btn-primary study-btn" data-id="${deck.id}">
+  Study
+</button>
+
                     <a href="#/edit/${deck.id}" class="btn btn-outline">Edit</a>
                     <button class="btn btn-danger btn-sm delete-btn" data-id="${deck.id}">REMOVE</button>
                 </div>
             `;
-            
+
             const deckActions = card.querySelector('.deck-actions');
-            
+
             // Add delete listener
             deckActions.addEventListener('click', (e) => {
                 console.log('Clicked deck actions', e.target);
+                if (e.target.classList.contains('study-btn')) {
+                    const deckId = e.target.dataset.id;
+                    const shuffleCheckbox = deckActions.querySelector('.shuffle-checkbox');
+                    const shuffleEnabled = shuffleCheckbox?.checked;
+
+                    window.location.hash = `#/study/${deckId}${shuffleEnabled ? '?shuffle=true' : ''}`;
+                    return;
+                }
+
                 if (e.target.classList.contains('delete-btn')) {
                     const btn = e.target;
                     const originalContent = btn.innerHTML;
-                    
+
                     // Switch to confirm mode
                     btn.classList.add('hidden'); // or remove
-                    
+
                     const confirmGroup = createElement('div', 'confirm-group');
                     confirmGroup.style.display = 'inline-flex';
                     confirmGroup.style.gap = '0.5rem';
-                    
+
                     const confirmBtn = createElement('button', 'btn btn-danger btn-sm', 'Yes');
                     const cancelBtn = createElement('button', 'btn btn-outline btn-sm', 'No');
-                    
+
                     confirmGroup.appendChild(confirmBtn);
                     confirmGroup.appendChild(cancelBtn);
-                    
+
                     btn.parentNode.appendChild(confirmGroup);
                     btn.style.display = 'none'; // hide original button
-                    
+
                     // Handle Confirm
                     confirmBtn.addEventListener('click', () => {
                         try {
                             StorageManager.deleteDeck(deck.id);
-                             // Re-render
+                            // Re-render
                             const newContent = render();
                             const app = document.getElementById('app');
                             app.innerHTML = '';
@@ -88,7 +112,7 @@ export function render() {
                             Toast.show('Error deleting: ' + err.message, 'error');
                         }
                     });
-                    
+
                     // Handle Cancel
                     cancelBtn.addEventListener('click', () => {
                         confirmGroup.remove();

--- a/OpenFlash/js/views/study.js
+++ b/OpenFlash/js/views/study.js
@@ -13,7 +13,12 @@ export function cleanup() {
 }
 
 export function render(deckId) {
-    const deck = StorageManager.getDeck(deckId);
+    const cleanDeckId = deckId.split('?')[0];
+    const urlParams = new URLSearchParams(window.location.hash.split('?')[1]);
+    const shuffleEnabled = urlParams.get('shuffle') === 'true';
+
+    const deck = StorageManager.getDeck(cleanDeckId);
+
     if (!deck) {
         window.location.hash = '#/dashboard';
         return createElement('div');
@@ -24,7 +29,12 @@ export function render(deckId) {
     let currentIndex = 0;
     let isFlipped = false;
     let sessionStats = { viewed: 0, correct: 0, incorrect: 0 };
-    
+    let sessionCards = [...deck.cards];
+
+    if (shuffleEnabled) {
+        sessionCards = shuffleArray(sessionCards);
+    }
+
     const container = createElement('div', 'study-view fade-in');
     
     // Header
@@ -38,7 +48,8 @@ export function render(deckId) {
     // Progress Indicator
     const progressIndicator = createElement('div', 'study-progress');
     const updateProgress = () => {
-        progressIndicator.textContent = `Card ${currentIndex + 1} of ${deck.cards.length}`;
+        progressIndicator.textContent = `Card ${currentIndex + 1} of ${sessionCards.length
+        }`;
     };
     updateProgress();
     container.appendChild(progressIndicator);
@@ -74,12 +85,13 @@ export function render(deckId) {
 
     // Logic
     const showCard = (index) => {
-        if (index >= deck.cards.length) {
+        if (index >= sessionCards.length
+        ) {
             finishSession();
             return;
         }
         
-        const card = deck.cards[index];
+        const card = sessionCards[index];
         frontFace.textContent = card.front;
         backFace.textContent = card.back;
         
@@ -103,9 +115,10 @@ export function render(deckId) {
 
     const handleRating = (correct) => {
         // Update stats
-        const currentProgress = StorageManager.getDeckProgress(deck.id);
+        const currentProgress = StorageManager.getDeckProgress(cleanDeckId);
         currentProgress.viewed++;
-        currentProgress.total = deck.cards.length; // Ensure total is up to date
+        currentProgress.total = sessionCards.length
+        ; // Ensure total is up to date
         
         if (correct) {
             currentProgress.correct++;
@@ -115,7 +128,7 @@ export function render(deckId) {
             sessionStats.incorrect++;
         }
         
-        StorageManager.saveDeckProgress(deck.id, currentProgress);
+        StorageManager.saveDeckProgress(cleanDeckId, currentProgress);
         
         // Next card
         currentIndex++;
@@ -149,7 +162,7 @@ export function render(deckId) {
             // Since we are inside the component, the cleanest SPA way without logic extraction is 
             // to trigger a route reload or just recursively call render (but we need to replace content).
             // Simplest: 
-            const newContent = render(deckId);
+            window.location.hash = `#/study/${cleanDeckId}${shuffleEnabled ? '?shuffle=true' : ''}`;
             const app = document.getElementById('app');
             app.innerHTML = '';
             app.appendChild(newContent);
@@ -184,7 +197,7 @@ export function render(deckId) {
     document.addEventListener('keydown', currentKeydownHandler);
 
     // Initialize
-    if (deck.cards.length === 0) {
+    if (sessionCards.length === 0) {
         container.innerHTML = `
             <div class="empty-state">
                 <p>This deck has no cards.</p>
@@ -196,4 +209,13 @@ export function render(deckId) {
     }
 
     return container;
+}
+
+function shuffleArray(array) {
+    const arr = [...array];
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
 }


### PR DESCRIPTION
Issue #31 

- Added Shuffle checkbox on dashboard
- When enabled, cards are shuffled only for the current session
- Progress tracking continues to use original card IDs
- Default study order remains unchanged

https://github.com/user-attachments/assets/279864f0-745b-4171-bb58-ee7256ce10db

